### PR TITLE
Remove deprecated url template tag load from future

### DIFF
--- a/suit_rq/templates/django_rq/clear_queue.html
+++ b/suit_rq/templates/django_rq/clear_queue.html
@@ -1,6 +1,5 @@
 {% extends "admin/base_site.html" %}
 
-{% load url from future %}
 
 {% block breadcrumb %}
     <ul class="breadcrumb">

--- a/suit_rq/templates/django_rq/confirm_action.html
+++ b/suit_rq/templates/django_rq/confirm_action.html
@@ -1,6 +1,5 @@
 {% extends "admin/base_site.html" %}
 
-{% load url from future %}
 
 {% block breadcrumbs %}
     <ul class="breadcrumb">

--- a/suit_rq/templates/django_rq/delete_job.html
+++ b/suit_rq/templates/django_rq/delete_job.html
@@ -1,6 +1,5 @@
 {% extends "admin/base_site.html" %}
 
-{% load url from future %}
 
 {% block breadcrumbs %}
     <ul class="breadcrumb">

--- a/suit_rq/templates/django_rq/job_detail.html
+++ b/suit_rq/templates/django_rq/job_detail.html
@@ -1,6 +1,5 @@
 {% extends "admin/base_site.html" %}
 
-{% load url from future %}
 
 {% block breadcrumbs %}
     <ul class="breadcrumb">

--- a/suit_rq/templates/django_rq/jobs.html
+++ b/suit_rq/templates/django_rq/jobs.html
@@ -1,7 +1,6 @@
 {% extends "admin/base_site.html" %}
 
 {% load admin_static %}
-{% load url from future %}
 
 {% block extrahead %}
     {{ block.super }}

--- a/suit_rq/templates/django_rq/stats.html
+++ b/suit_rq/templates/django_rq/stats.html
@@ -1,7 +1,6 @@
 {% extends "admin/base_site.html" %}
 
 {% load i18n %}
-{% load url from future %}
 
 {% block content_title %}<h1>RQ Queues</h1>{% endblock %}
 


### PR DESCRIPTION
Adds Django 1.9 support and removes deprecation warning under 1.8:

```
RemovedInDjango19Warning: Loading the `url` tag from the `future` library is deprecated and will be removed in Django 1.9. Use the default `url` tag instead.
```

Note that this drops support for Django <1.5, but as [django-rq itself requires 1.5](https://github.com/ui/django-rq#requirements), that shouldn't be an issue.
